### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import updown
-
 setup(name='updown',
-      version = updown.__version__,
+      version = '0.2.0',
       description='3rd-party Python interface to Updown.io API',
       author='Brandon Hamilton',
       author_email='brandon.hamilton@gmail.com',

--- a/updown/__init__.py
+++ b/updown/__init__.py
@@ -22,11 +22,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-__version__ = '0.1.0'
-__author__ = 'Brandon Hamilton <brandon.hamilton@gmail.com>'
-__copyright__ = "Copyright (c) 2015 Brandon Hamilton"
-__license__ = "MIT"
-
 import os
 import requests
 


### PR DESCRIPTION
`updown` was imported in setup.py (because of the version string I guess) and that caused an issue during `pip install`. I removed this and also the maintainer details from `__init__.py` because they were redundant.

`pip install` is working for me again, I had the same issue as @mlissner in https://github.com/brandonhamilton/updown-python/issues/2 , so likely that issue can be closed as well.